### PR TITLE
refactor: option2 선택되지 않았을 때, api 요청 방지

### DIFF
--- a/src/searchPage/SearchDropBox.jsx
+++ b/src/searchPage/SearchDropBox.jsx
@@ -174,6 +174,9 @@ function SearchDropBox({
 
   useEffect(() => {
     const fetchDataAndUpdateState = async () => {
+      // option2가 선택되지 않았으면 API 요청을 하지 않음
+      if (!option2) return;
+
       await Promise.all([
         setPage(0),
         setHasMore(true),


### PR DESCRIPTION
검색 페이지에서, 단과대 선택하고 경영대학을 선택해야 api 요청을 날려야하는데, 
option1인 단과대를 선택하면 바로 option2가 undefined인 상태로 api 요청을 날려서 코드를 수정함