### PR TITLE
fix: 검색 탭에서 공지사항 변경 시 페이지 번호가 1로 뜨는 문제 해결 (#59)

### DIFF
--- a/src/searchPage/SearchEventPage.jsx
+++ b/src/searchPage/SearchEventPage.jsx
@@ -121,7 +121,11 @@ export default function SearchEventPage() {
           option1={option1}
           setOption1={setOption1}
           option2={option2}
-          setOption2={setOption2}
+          setOption2={(newOption2) => {
+            setOption2(newOption2);
+            setPage(0);
+            setHasMore(true);
+          }}
           savedOption1={savedOption1}
           setSavedOption1={setSavedOption1}
           savedOption2={savedOption2}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#59)

## 💻 작업 내용

> 검색 탭에서 다른 공지사항을 검색하려고 옵션 변경시 페이지 번호가 1로 뜨는 문제를 해결

- [x] 다른 옵션 클릭시 setPage(0), setHasMore(true)로 초기화

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
