### PR TITLE
fix: 키워드탭에서 상세 게시글로 이동시 event/undefined 경로로 뜨는 문제 해결 (#62)

### DIFF
--- a/src/subscribePage/KeywordTab.jsx
+++ b/src/subscribePage/KeywordTab.jsx
@@ -107,6 +107,7 @@ export default function KeywordTab() {
         {events.map((event, index) => (
           <KeywordEventCard
             key={`${event.eventId}-${index}`}
+            id={event.eventId}
             {...event}
           />
         ))}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#62)

## 💻 작업 내용

> 키워드탭에서 상세 게시글로 이동시 event/undefined 경로로 뜨는 문제 해결

- [x] KeywordEventCard에서 id={event.eventId} 전달 추가
- [x] 이벤트 상세 페이지로 이동 시 eventId가 undefined로 전달되던 문제 해결
- [x] KeywordTab에서 올바르게 데이터가 전달되도록 개선

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
