### PR TITLE
feat: 핸드폰 홈 화면 아이콘의 앱 뱃지 설정 (#75)

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -7,50 +7,48 @@ self.addEventListener("activate", function (e) {
   console.log("fcm sw activate..");
 });
 
-self.addEventListener("push", function (e) {
-  if (!e.data || !e.data.json()) {
+self.addEventListener("push", function (event) {
+  if (!event.data || !event.data.json()) {
     console.error("Push event does not contain valid JSON data.");
     return;
   }
 
-  const resultData = e.data.json().notification;
-  const resultURL = e.data.json().data.click_action;
+  const data = event.data.json();
+  console.log("Received push notification:", data);
 
-  const pushClusterId = e.data.json().data.push_cluster_id;
+  // 🔹 `unread_count`가 문자열일 경우 숫자로 변환
+  const unreadCount = data.data?.unread_count ? Number(data.data.unread_count) : 0;
+  console.log("Parsed unread count:", unreadCount);
+  
 
-  if (!resultData || !resultData.title || !resultData.body) {
-    const notificationTitle = "Notification data is incomplete.";
-    const notificationOptions = {
-      body: "Notification data is incomplete.",
-    };
-    self.registration.showNotification(notificationTitle, notificationOptions);
-    return;
+  let promises = [];
+
+  // 🔹 iOS 및 지원되는 기기에서 배지 업데이트
+  if ("setAppBadge" in self.navigator) {
+    console.log(unreadCount)
+    const badgePromise = self.navigator.setAppBadge(unreadCount).catch(console.error);
+    promises.push(badgePromise);
   }
 
-  const notificationTitle = resultData.title;
-  const notificationOptions = {
-    body: resultData.body.split("\\n").join("\n"),
-    icon: resultData.image,
-    tag: resultData.tag,
-    data: { 
-      click_action: resultURL,
-      push_cluster_id: pushClusterId,
-    },
-  };
+  // 🔹 iOS에서는 showNotification() 필수 실행
+  const notificationPromise = self.registration.showNotification(data.notification.title, {
+    body: data.notification.body,
+    icon: data.notification.icon,
+    data: { click_action: data.data.click_action },
+  });
+  promises.push(notificationPromise);
 
-  self.registration.showNotification(notificationTitle, notificationOptions);
-
-  let badgeCount = 0; // 초기 뱃지 카운트
-
-  //app.js에 뱃지 업데이트 메시지 전달
+  // 🔹 PWA 실행 중일 경우 UI 동기화
   self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
     clients.forEach((client) => {
       client.postMessage({
         type: "updateBadge",
-        count: badgeCount,
+        count: unreadCount, // 🟢 안 읽은 알림 개수 전달
       });
     });
   });
+
+  event.waitUntil(Promise.all(promises));
 });
 
 self.addEventListener("notificationclick", function (event) {

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -32,6 +32,8 @@ const useStore = create((set) => ({
     set({ isAuthorized: true });
   },
 
+  setUnreadNotificationCount: (count) => set({ unreadNotificationCount: count }),
+
   // 안 읽은 푸시 알림 배지 개수 가져오는 함수
   fetchUnreadNotificationCount: async () => {
     try {


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#75)

## 💻 작업 내용

> (작업내용작성)

- [x] 서비스워커에서 FCM 푸시 알림을 받을 때 푸시 메시지에서 unread_count를 파싱하여 안 읽은 알림 개수 관리 추가
- [x] showNotification()과 setAppBadge()를 통해 배지 업데이트 처리
- [x] PWA 실행 중일 경우, 서비스워커에서 메인 앱으로 안 읽은 알림 개수 전달 (postMessage 활용)
- [x] 	서비스워커로부터 updateBadge 메시지를 수신하면, fetchUnreadNotificationCount() 호출하여 서버에서 최신 알림 개수 조회
- [x] 동시에 setUnreadNotificationCount()로 상태 업데이트
- [x] 포그라운드 진입 시 setAppBadge()로 배지 동기화 처리 추가
- [x] setUnreadNotificationCount() 추가

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

https://github.com/user-attachments/assets/00ad653d-ddb6-47ba-aac9-173d4d601c84
<img width="718" alt="image" src="https://github.com/user-attachments/assets/dbaa6277-9f9d-4957-9239-4ca6b889a0a6" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
