### PR TITLE
refactor: 구독탭 뱃지 로직 변경 (#68)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -88,7 +88,11 @@ const ROUTER = createBrowserRouter([
 ]);
 
 function App() {
-  const { unreadNotificationCount, setUnreadNotificationCount } = useStore();
+  const { fetchMemberStatus, unreadNotificationCount, setUnreadNotificationCount } = useStore();
+
+  useEffect(() => {
+    fetchMemberStatus();
+  }, []);
 
   useEffect(() => {
     if ("serviceWorker" in navigator) {

--- a/src/components/NavigationBar.jsx
+++ b/src/components/NavigationBar.jsx
@@ -109,13 +109,13 @@ function NavigationBar() {
   const currentPath = location.pathname;
 
   // 전역 상태에서 읽음 상태 관리 (서버 변수명 그대로 사용)
-  const { isTopicTabRead, isKeywordTabRead, fetchMemberStatus } = useStore();
+  const { isSubscribedTabRead, fetchMemberStatus } = useStore();
 
   const [isIOS, setIsIOS] = useState(false);
   const [shouldShowPWAPrompt, setShouldShowPWAPrompt] = useState(false);
 
   useEffect(() => {
-    fetchMemberStatus(); // 페이지 로드 시 사용자 구독 상태 가져오기
+    // fetchMemberStatus(); // 페이지 로드 시 사용자 구독 상태 가져오기
     // iOS 장치인지 확인
     const isDeviceIOS =
       /iPad|iPhone|iPod/.test(window.navigator.userAgent) && !window.MSStream;
@@ -150,8 +150,7 @@ function NavigationBar() {
                 />
                 <NavLabel>{item.label}</NavLabel>
                 {/* 구독 탭에 뱃지 표시 */}
-                {item.label === '구독' &&
-                  (!isTopicTabRead || !isKeywordTabRead) && <Badge />}
+                {item.label === '구독' && isSubscribedTabRead === false && <Badge />}
               </NavItem>
             );
           })}

--- a/src/pages/subscribePage/KeywordBar.jsx
+++ b/src/pages/subscribePage/KeywordBar.jsx
@@ -94,7 +94,7 @@ const KeywordBar = ({ onKeywordSelect }) => {
   const [selectedKeyword, setSelectedKeyword] = useState(null);
 
   useEffect(() => {
-    fetchSubscribedKeywords();
+    // fetchSubscribedKeywords();
   }, []);
 
   useEffect(() => {

--- a/src/pages/subscribePage/SubscribePage.jsx
+++ b/src/pages/subscribePage/SubscribePage.jsx
@@ -83,7 +83,7 @@ const SubscribeContainer = styled.div`
 
 export default function SubscribePage() {
   const location = useLocation();
-  const { isTopicTabRead, isKeywordTabRead, fetchMemberStatus } = useStore();
+  const { subscribeItems, subscribedKeywords, fetchSubscribeItems, fetchSubscribedKeywords } = useStore();
   const [activeTab, setActiveTab] = useState(
     location.state?.activeTab || 'subscribe',
   );
@@ -91,7 +91,8 @@ export default function SubscribePage() {
   const accessToken = localStorage.getItem('accessToken');
 
   useEffect(() => {
-    fetchMemberStatus();
+    // fetchSubscribeItems();
+    fetchSubscribedKeywords();
   }, []);
 
   const handleTabClick = async (tabName) => {
@@ -104,21 +105,17 @@ export default function SubscribePage() {
         <MainContentContaioner>
           <LocationBar location="구독" />
           <TabContainer>
-            <Tab
-              active={activeTab === 'subscribe'}
-              onClick={() => handleTabClick('subscribe')}
-            >
-              구독 알림
-              {!isTopicTabRead && <Badge />} {/* 읽지 않은 상태면 뱃지 표시 */}
-            </Tab>
-            <Tab
-              active={activeTab === 'keyword'}
-              onClick={() => handleTabClick('keyword')}
-            >
-              키워드 알림
-              {!isKeywordTabRead && <Badge />}{' '}
-              {/* 읽지 않은 상태면 뱃지 표시 */}
-            </Tab>
+              <Tab active={activeTab === 'subscribe'} 
+                onClick={() => setActiveTab('subscribe')}>
+                구독 알림
+                {subscribeItems.some((item) => !item.isRead) && <Badge />}
+              </Tab>
+
+              <Tab active={activeTab === 'keyword'} 
+                onClick={() => setActiveTab('keyword')}>
+                키워드 알림
+                {subscribedKeywords.some((item) => !item.isRead) && <Badge />}
+              </Tab>
           </TabContainer>
           {activeTab === 'subscribe' && (
             <SubscribeContainer>

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -2,22 +2,42 @@ import { create } from 'zustand';
 import requestWithAccessToken from '../services/jwt/requestWithAccessToken';
 
 // useStore.js
-const useStore = create((set) => ({
+const useStore = create((set, get) => ({
   savedKeyword: '',
   savedOption1: '',
   savedOption2: '아주대학교-일반',
   isAuthorized: false,
   isTopicTabRead: true,
   isKeywordTabRead: true,
+  isSubscribedTabRead: true,
   unreadNotificationCount: 0, // 푸시 알림 배지 개수 상태
   topics: [], // 사용자가 구독한 topics
   subscribeItems: [], // 구독된 항목들을 저장하는 상태 추가
   keywords: [], // 사용자가 구독한 keywords
   subscribedKeywords: [], // 구독된 키워드들을 저장하는 상태 추가
 
-  setSubscribeItems: (items) => set({ subscribeItems: items }),
+  setSubscribeItems: (items) => {
+    set({ subscribeItems: items });
+    get().updateTabReadStatus(); 
+  },
 
-  setSubscribedKeywords: (keywords) => set({ subscribedKeywords: keywords }),
+  setSubscribedKeywords: (keywords) => {
+    set({ subscribedKeywords: keywords });
+    get().updateTabReadStatus();
+  },
+
+  // 상태 업데이트 로직 (전체 읽음 여부 체크)
+  updateTabReadStatus: () => {
+    const { subscribeItems, subscribedKeywords } = get();
+    const allTopicsRead = subscribeItems.every((item) => item.isRead);
+    const allKeywordsRead = subscribedKeywords.every((item) => item.isRead);
+
+    set({
+      isTopicTabRead: allTopicsRead,
+      isKeywordTabRead: allKeywordsRead,
+      isSubscribedTabRead: allTopicsRead && allKeywordsRead,
+    });
+  },
 
   setSavedKeyword: (savedKeyword) => {
     set({ savedKeyword });
@@ -60,11 +80,13 @@ const useStore = create((set) => ({
 
       // 모든 항목이 읽음 상태인지 확인하여 isTopicTabRead를 갱신
       const allTopicsRead = updatedItems.every((item) => item.isRead === true);
+      const allKeywordsRead = get().subscribedKeywords.every((item) => item.isRead === true);
 
       // 상태 업데이트
       set({
         subscribeItems: updatedItems,
         isTopicTabRead: allTopicsRead,
+        isSubscribedTabRead: allTopicsRead && allKeywordsRead,
       });
 
       // 모든 항목이 읽음 상태일 경우 서버에 읽음 상태 업데이트
@@ -96,11 +118,13 @@ const useStore = create((set) => ({
       const allKeywordsRead = updatedItems.every(
         (item) => item.isRead === true,
       );
+      const allTopicsRead = get().subscribeItems.every((item) => item.isRead === true);
 
       // 상태 업데이트
       set({
         subscribedKeywords: updatedItems,
         isKeywordTabRead: allKeywordsRead,
+        isSubscribedTabRead: allTopicsRead && allKeywordsRead, 
       });
 
       // 모든 항목이 읽음 상태일 경우 서버에 읽음 상태 업데이트
@@ -141,7 +165,16 @@ const useStore = create((set) => ({
     }
   },
 
-  // setIsSubscribedTabRead: (isRead) => set({ isSubscribedTabRead: isRead }),
+  setIsSubscribedTabRead: (isRead) => set({ isSubscribedTabRead: isRead }),
+  
+  updateSubscribedTabRead: async () => {
+    try {
+      const response = await requestWithAccessToken('get', `${process.env.REACT_APP_BE_URL}/api/subscriptions/isSubscribedTabRead`);
+      set({ isSubscribedTabRead: response.data.isSubscribedTabRead });
+    } catch (error) {
+      console.error('Error updating isSubscribedTabRead:', error);
+    }
+  },
 
   // 모든 topic의 읽음 상태 확인 및 구독 탭 뱃지 업데이트
   updateTopicReadStatus: (topics) => {
@@ -159,12 +192,10 @@ const useStore = create((set) => ({
     try {
       const response = await requestWithAccessToken(
         'get',
-        `${process.env.REACT_APP_BE_URL}/api/event/readStatus`,
+        `${process.env.REACT_APP_BE_URL}/api/subscriptions/isSubscribedTabRead`,
       );
       set({
-        isTopicTabRead: response.data.isTopicTabRead,
-        isKeywordTabRead: response.data.isKeywordTabRead,
-        // isSubscribedTabRead: response.data.isTopicTabRead && response.data.isKeywordTabRead,
+        isSubscribedTabRead: response.data.subscribedTabRead,
       });
     } catch (error) {
       console.error('Error fetching read status', error);
@@ -193,6 +224,7 @@ const useStore = create((set) => ({
       );
       const keywords = response.data;
       set({ subscribedKeywords: keywords });
+      get().updateTabReadStatus();
     } catch (error) {
       console.error('Error fetching subscribed keywords', error);
     }
@@ -207,6 +239,7 @@ const useStore = create((set) => ({
       );
       const topics = response.data;
       set({ subscribeItems: topics });
+      get().updateTabReadStatus();
     } catch (error) {
       console.error('Error fetching subscribe items:', error);
     }


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#68)

## 💻 작업 내용

> (작업내용작성)

- [x] 서버에서 구독탭 상태 불러오는 api 변경 
- [x] 네비게이션바가 아닌 App.js에서 구독탭 상태 불러오는 api 호출
- [x] 네비게이션바, SubscribePage 중복호출 삭제

### 테스트 결과 or 스크린샷 (선택)

> 작업한 부분을 캡처해 보여주면 이해하기 쉬워요

https://github.com/user-attachments/assets/d43914a5-75be-4721-b0a2-9c688072c748

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
