### PR TITLE
feat: 회원가입 이후 학과 정보 등록 완료 후, 구독 페이지로 이동하여 구독 가이드라인 노출 처리

### DIFF
--- a/src/pages/subscribePage/KeywordBar.jsx
+++ b/src/pages/subscribePage/KeywordBar.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import useStore from '../../store/useStore';
 
@@ -14,12 +14,14 @@ const Container = styled.div`
 const MenuBarContainer = styled.div`
   width: 100%;
   display: flex;
+  align-items: center;
   overflow-x: auto;
   white-space: nowrap;
   background: #ffffff;
-  padding: 12px 10px 0px 16px;
+  padding: ${({ highlight }) => (highlight ? '18px 10px 18px 12px' : '12px 10px 0px 16px')};
   font-family: 'Pretendard Variable';
   font-weight: 600;
+  box-sizing: border-box;
 `;
 
 const MenuItemContainer = styled.div`
@@ -49,6 +51,12 @@ const MenuItem = styled.div`
   cursor: pointer;
 `;
 
+const ViewAllButtonWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;  // 구독 설정과 툴팁 사이 여백
+`;
+
 const ViewAllButton = styled.div`
   display: flex;
   height: fit-content;
@@ -57,12 +65,41 @@ const ViewAllButton = styled.div`
   align-items: center;
   gap: 4px;
   border-radius: 600px;
-  border: 2px solid #f7f7f7; // 회색 테두리
-  background-color: #e0e0e0; // 회색 배경
+  border: 2px solid #f7f7f7;
+  background-color: #ffffff;
   cursor: pointer;
+  font-size: 14px;
+  white-space: nowrap;
+  box-sizing: border-box;
+  animation: ${({ highlight }) => highlight ? glowAnimation : 'none'} 1.5s infinite;
+
+  background-color: ${(props) =>
+    props.isSelected ? '#e0e0e0' : '#ffffff'}; /* 항상 회색 유지 */
   p {
-    margin: 0;
-    color: #333; // 텍스트 색상 조정
+    margin: 0
+`;
+
+const InlineTooltip = styled.div`
+  background-color: #0072ce;
+  color: #ffffff;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: bold;
+  white-space: nowrap;
+  line-height: 1.4;
+  display: ${({ show }) => (show ? 'block' : 'none')};
+  animation: fadeIn 0.5s ease-in-out;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-3px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 `;
 
@@ -82,7 +119,14 @@ const NotificationBadge = styled.div`
   }};
 `;
 
-const KeywordBar = ({ onKeywordSelect }) => {
+const glowAnimation = keyframes`
+  0% { box-shadow: 0 0 8px rgba(0, 114, 206, 0.6); }
+  50% { box-shadow: 0 0 15px rgba(0, 114, 206, 0.9); }
+  100% { box-shadow: 0 0 8px rgba(0, 114, 206, 0.6); }
+`;
+
+
+const KeywordBar = ({ onKeywordSelect, showGuide }) => {
   const {
     isKeywordTabRead,
     setIsKeywordTabRead,
@@ -124,19 +168,25 @@ const KeywordBar = ({ onKeywordSelect }) => {
 
   return (
     <Container>
-      <MenuBarContainer>
-        <ViewAllButton
-          onClick={() =>
-            navigate('/subscribe/keywordSubscribe', {
-              state: { tab: 'keyword' },
-            })
-          }
-        >
-          <ViewAllIcon
-            src={`${process.env.PUBLIC_URL}/icons/alarm_filled.svg`}
-          />
-          <p>키워드 설정</p>
-        </ViewAllButton>
+      <MenuBarContainer highlight={showGuide}>
+        <ViewAllButtonWrapper>
+           <ViewAllButton isSelected={true}
+            onClick={() =>
+              navigate('/subscribe/keywordSubscribe', {
+                state: { tab: 'keyword' },
+              })
+            }
+            highlight={showGuide}
+          >
+            <ViewAllIcon
+              src={`${process.env.PUBLIC_URL}/icons/alarm_filled.svg`}
+            />
+            <p>키워드 설정</p>
+          </ViewAllButton>
+          <InlineTooltip show={showGuide}>
+            클릭해서 구독하기
+          </InlineTooltip>
+        </ViewAllButtonWrapper> 
         <MenuItemContainer>
           {subscribedKeywords.map((item, index) => (
             <MenuItem

--- a/src/pages/subscribePage/KeywordTab.jsx
+++ b/src/pages/subscribePage/KeywordTab.jsx
@@ -35,7 +35,7 @@ const MessageContainer = styled.div`
   padding: 16px;
 `;
 
-export default function KeywordTab() {
+export default function KeywordTab({ showGuide }) {
   const { setIsKeywordTabRead } = useStore((state) => ({
     setIsKeywordTabRead: state.setIsKeywordTabRead,
   }));
@@ -114,7 +114,7 @@ export default function KeywordTab() {
 
   return (
     <AppContainer>
-      <KeywordBar onKeywordSelect={handleKeywordSelect} />
+      <KeywordBar onKeywordSelect={handleKeywordSelect} showGuide={showGuide} />
       <SearchBar setKeyword={setSelectedKeyword} />
       <KeywordListContainer>
         {events.map((event, index) => (

--- a/src/pages/subscribePage/SubscribeBar.jsx
+++ b/src/pages/subscribePage/SubscribeBar.jsx
@@ -15,12 +15,14 @@ const Container = styled.div`
 const MenuBarContainer = styled.div`
   width: 100%;
   display: flex;
+  align-items: center;
   overflow-x: auto;
   white-space: nowrap;
   background: #ffffff;
-  padding: 12px 10px 0px 16px;
+  padding: ${({ highlight }) => (highlight ? '18px 10px 18px 12px' : '12px 10px 0px 16px')};
   font-family: 'Pretendard Variable';
   font-weight: 600;
+  box-sizing: border-box;
 `;
 
 const MenuItemContainer = styled.div`
@@ -50,6 +52,12 @@ const MenuItem = styled.div`
   cursor: pointer;
 `;
 
+const ViewAllButtonWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;  // 구독 설정과 툴팁 사이 여백
+`;
+
 const ViewAllButton = styled.div`
   display: flex;
   height: fit-content;
@@ -61,10 +69,38 @@ const ViewAllButton = styled.div`
   border: 2px solid #f7f7f7;
   background-color: #ffffff;
   cursor: pointer;
+  font-size: 14px;
+  white-space: nowrap;
+  box-sizing: border-box;
+  animation: ${({ highlight }) => highlight ? glowAnimation : 'none'} 1.5s infinite;
+
   background-color: ${(props) =>
     props.isSelected ? '#e0e0e0' : '#ffffff'}; /* 항상 회색 유지 */
   p {
-    margin: 0;
+    margin: 0
+`;
+
+const InlineTooltip = styled.div`
+  background-color: #0072ce;
+  color: #ffffff;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: bold;
+  white-space: nowrap;
+  line-height: 1.4;
+  display: ${({ show }) => (show ? 'block' : 'none')};
+  animation: fadeIn 0.5s ease-in-out;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-3px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
   }
 `;
 
@@ -262,7 +298,13 @@ const Toast = Swal.mixin({
   },
 });
 
-const SubscribeBar = ({ onTopicSelect }) => {
+const glowAnimation = keyframes`
+  0% { box-shadow: 0 0 8px rgba(0, 114, 206, 0.6); }
+  50% { box-shadow: 0 0 15px rgba(0, 114, 206, 0.9); }
+  100% { box-shadow: 0 0 8px rgba(0, 114, 206, 0.6); }
+`;
+
+const SubscribeBar = ({ onTopicSelect, showGuide }) => {
   const {
     isTopicTabRead,
     setIsTopicTabRead,
@@ -463,11 +505,16 @@ const SubscribeBar = ({ onTopicSelect }) => {
 
   return (
     <Container>
-      <MenuBarContainer>
-        <ViewAllButton isSelected={true} onClick={handleShowModal}>
-          <ViewAllIcon src={`${process.env.PUBLIC_URL}/icons/gear.svg`} />
-          <p>구독 설정</p>
-        </ViewAllButton>
+      <MenuBarContainer highlight={showGuide}>
+        <ViewAllButtonWrapper>
+          <ViewAllButton isSelected={true} onClick={handleShowModal} highlight={showGuide}>
+            <ViewAllIcon src={`${process.env.PUBLIC_URL}/icons/gear.svg`} />
+            <p>구독 설정</p>
+          </ViewAllButton>
+          <InlineTooltip show={showGuide}>
+            클릭해서 구독하기
+          </InlineTooltip>
+        </ViewAllButtonWrapper>
         <MenuItemContainer>
           {Array.isArray(subscribeItems) ? (
             subscribeItems.map((item) => (

--- a/src/pages/subscribePage/SubscribePage.jsx
+++ b/src/pages/subscribePage/SubscribePage.jsx
@@ -81,22 +81,84 @@ const SubscribeContainer = styled.div`
   width: 100%;
 `;
 
+const GuideMessage = styled.div`
+  width: 100%;
+  padding: 12px;
+  background-color: #f0f8ff;
+  font-size: 13px;
+  color: #0072ce;
+  text-align: center;
+  font-weight: 600;
+  line-height: 1.5; /* 줄 간격 확보 */
+  word-break: keep-all; /* 단어 단위로 줄바꿈 */
+  white-space: normal; /* 강제 줄바꿈 허용 */
+
+  @media (max-width: 375px) {  // iPhone SE 같은 작은 화면 대응
+    font-size: 12px;
+    padding: 8px;
+  }
+
+  @media (max-width: 320px) {  // 더 작은 화면일 때
+    font-size: 11px;
+    padding: 6px;
+  }
+`;
+
 export default function SubscribePage() {
   const location = useLocation();
   const { subscribeItems, subscribedKeywords, fetchSubscribeItems, fetchSubscribedKeywords } = useStore();
   const [activeTab, setActiveTab] = useState(
     location.state?.activeTab || 'subscribe',
   );
+  const [showGuide, setShowGuide] = useState(false);
 
   const accessToken = localStorage.getItem('accessToken');
 
+  // 구독 아이템/키워드 변화 감지해 showGuide 판단
+  useEffect(() => {
+    if (activeTab === 'subscribe') {
+      setShowGuide(subscribeItems.length === 0);
+    } else if (activeTab === 'keyword') {
+      setShowGuide(subscribedKeywords.length === 0);
+    }
+  }, [subscribeItems, subscribedKeywords, activeTab]);
+
   useEffect(() => {
     // fetchSubscribeItems();
-    fetchSubscribedKeywords();
+    fetchSubscribedKeywords(); // 여기에서 가져와야 키워드 알림 탭의 뱃지를 보여줄 수 있음
   }, []);
 
   const handleTabClick = async (tabName) => {
     setActiveTab(tabName);
+  };
+
+  const getGuideMessage = (activeTab) => {
+    if (activeTab === 'subscribe') {
+      return (
+        <>
+          아직 구독한 항목이 없습니다.
+          <br />
+          아래의 <strong>⚙️ 구독 설정</strong>에서 관심있는 공지를 구독해보세요!
+        </>
+      );
+    } else if (activeTab === 'keyword') {
+      return (
+        <>
+          아직 구독한 키워드가 없습니다.
+          <br />
+          아래의 <strong>🔔 키워드 설정</strong>에서 관심있는 키워드를 구독해보세요!
+        </>
+      );
+    } else {
+      // 기본 메시지 (탭 선택 전이거나, 예외 상황 대비)
+      return (
+        <>
+          아직 구독한 항목이 없습니다.
+          <br />
+          아래의 톱니바퀴/종 모양의 <strong>'설정'</strong>에서 관심있는 공지를 구독해보세요!
+        </>
+      );
+    }
   };
 
   return (
@@ -104,6 +166,11 @@ export default function SubscribePage() {
       {accessToken ? (
         <MainContentContaioner>
           <LocationBar location="구독" />
+          {showGuide && (
+            <GuideMessage>
+              {getGuideMessage(activeTab)}
+            </GuideMessage>
+          )}
           <TabContainer>
               <Tab active={activeTab === 'subscribe'} 
                 onClick={() => setActiveTab('subscribe')}>
@@ -119,12 +186,12 @@ export default function SubscribePage() {
           </TabContainer>
           {activeTab === 'subscribe' && (
             <SubscribeContainer>
-              <SubscribeTab />
+              <SubscribeTab showGuide={showGuide} />
             </SubscribeContainer>
           )}
           {activeTab === 'keyword' && (
             <SubscribeContainer>
-              <KeywordTab />
+              <KeywordTab showGuide={showGuide} />
             </SubscribeContainer>
           )}
         </MainContentContaioner>

--- a/src/pages/subscribePage/SubscribeTab.jsx
+++ b/src/pages/subscribePage/SubscribeTab.jsx
@@ -13,7 +13,7 @@ const AppContainer = styled.div`
   background-color: #ffffff;
 `;
 
-export default function SubscribeTab() {
+export default function SubscribeTab({ showGuide }) {
   const { savedKeyword, setSavedKeyword } = useStore((state) => ({
     savedKeyword: state.savedKeyword,
     setSavedKeyword: state.setSavedKeyword,
@@ -106,7 +106,7 @@ export default function SubscribeTab() {
 
   return (
     <AppContainer>
-      <SubscribeBar onTopicSelect={handleTopicSelect} />
+      <SubscribeBar onTopicSelect={handleTopicSelect} showGuide={showGuide} />
       <SearchBar
         keyword={keyword}
         setKeyword={setKeyword}


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#83)

## 💻 작업 내용

> (작업내용작성)

- [x]	이동 시 state로 showGuide 값을 함께 전달 (토픽, 키워드 구독 개수로 상태 설정)
- [x] 구독 설정 버튼에 가이드용 애니메이션(glow 효과) 추가
- [x] showGuide가 true일 때만 표시, 구독 항목이 하나라도 존재하면 숨김 처리
- [x] KeywordBar에도 동일한 흐름 적용
- [x] 학과 등록 후 키워드 설정 진입 시, 키워드 설정 버튼에도 툴팁과 애니메이션 표시

### 테스트 결과 or 스크린샷 (선택)

> 
<img width="273" alt="image" src="https://github.com/user-attachments/assets/87417370-d08b-4e3d-9ca2-247bfb684622" />
<img width="273" alt="image" src="https://github.com/user-attachments/assets/30919b23-8080-4dee-82b0-84d135aaa0e8" />

https://github.com/user-attachments/assets/ab334350-5814-4760-ae54-63fff15520b4



## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
