### PR TITLE
chore: ESLint 에러 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "@vercel/analytics": "^1.3.1",
+        "@vercel/analytics": "^1.6.1",
         "axios": "^1.7.3",
         "bootstrap": "^5.3.3",
         "dotenv": "^16.4.5",
@@ -4563,95 +4563,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.0.0.tgz",
-      "integrity": "sha512-PmJPnogldqoVFf+EwbHvbBJ98MmqASV8kLrBYgsDNxQcFMeIS7JFL48sfyXvuMtgmWO/wMhh25odr+8VhDmn4g==",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@testing-library/dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.17.0",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
@@ -5688,21 +5599,39 @@
       "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA=="
     },
     "node_modules/@vercel/analytics": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.3.1.tgz",
-      "integrity": "sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==",
-      "dependencies": {
-        "server-only": "^0.0.1"
-      },
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
       "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
         "next": ">= 13",
-        "react": "^18 || ^19"
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
       },
       "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
         "next": {
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
           "optional": true
         }
       }
@@ -17483,11 +17412,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/server-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
-      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA=="
-    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -18918,19 +18842,6 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@vercel/analytics": "^1.3.1",
+    "@vercel/analytics": "^1.6.1",
     "axios": "^1.7.3",
     "bootstrap": "^5.3.3",
     "dotenv": "^16.4.5",

--- a/src/App.js
+++ b/src/App.js
@@ -89,7 +89,7 @@ function App() {
 
   useEffect(() => {
     fetchMemberStatus();
-  }, []);
+  }, [fetchMemberStatus]);
 
   useEffect(() => {
     if ("serviceWorker" in navigator) {

--- a/src/components/DeleteAccount.jsx
+++ b/src/components/DeleteAccount.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Swal from 'sweetalert2';
 import styled from 'styled-components';
-import { STORAGE_KEYS } from '../constants/appConstants';
 import { resetTopicSubscriptions, resetKeywordSubscriptions } from '../services/api/subscription';
 import { deleteUser } from '../services/api/user';
 import { clearAuth } from '../utils/auth';
@@ -47,7 +46,6 @@ const DeleteAccountPage = () => {
   const [reason, setReason] = useState('');
   const [nextStep, setNextStep] = useState(false);
   const navigate = useNavigate();
-  const accessToken = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
 
   const handleTopicReset = async () => {
     setIsLoadingTopic(true); // 로딩 시작

--- a/src/components/HelpBox.jsx
+++ b/src/components/HelpBox.jsx
@@ -69,7 +69,7 @@ const HelpBox = () => {
 
   useEffect(() => {
     fetchUnreadNotificationCount(); // 처음 마운트될 때 최신 알림 개수 가져오기
-  }, []);
+  }, [fetchUnreadNotificationCount]);
 
   const handleBellClick = () => {
     navigate('/notification');

--- a/src/components/PrivacyAgreement.jsx
+++ b/src/components/PrivacyAgreement.jsx
@@ -302,7 +302,7 @@ const PrivacyAgreement = () => {
         <>
           <Overlay onClick={closeModal} />
           <Modal>
-            <h2></h2>
+            <h2 aria-hidden="true">{' '}</h2>
             {/* Render HTML content in the modal */}
             <div dangerouslySetInnerHTML={{ __html: modalContent }} />
             <Button onClick={handleModalConfirm}>확인</Button>

--- a/src/components/ProfileModification.jsx
+++ b/src/components/ProfileModification.jsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { STORAGE_KEYS, COLORS } from '../constants/appConstants';
+import { COLORS } from '../constants/appConstants';
 
 const ProfileContainer = styled.div`
   display: flex;
@@ -118,7 +118,6 @@ const DeleteAccountLink = styled.span`
 const ProfileModification = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
-  const accessToken = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
 
   const user = state?.user;
   console.log('user', user);

--- a/src/components/events/EventDetail.jsx
+++ b/src/components/events/EventDetail.jsx
@@ -9,19 +9,6 @@ import ImageModal from './ImageModal';
 import { Z_INDEX, STORAGE_KEYS, COLORS } from '../../constants/appConstants';
 import { getEventDetail, getAuthEventDetail, likeEvent, unlikeEvent } from '../../services/api/event';
 
-const ModalOverlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: ${Z_INDEX.MODAL};
-`;
-
 const Container = styled.div`
   width: 100%;
   height: 100%;
@@ -80,17 +67,6 @@ const TitleContainer = styled.div`
   font-style: normal;
   font-weight: 700;
   line-height: 130%; /* 26px */
-`;
-
-const LinkButton = styled.div`
-  text-align: center;
-  width: 100%;
-  padding: 10px 20px;
-  border-radius: 4px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  margin: 24px 0 16px 0;
-  cursor: pointer;
-  display: inline-block;
 `;
 
 const ContentContaioner = styled.div`

--- a/src/pages/homePage/HomeHotEvent.jsx
+++ b/src/pages/homePage/HomeHotEvent.jsx
@@ -34,6 +34,7 @@ export default function HomeHotEvent() {
       }
     };
     loadHotEvent();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/pages/homePage/HomePage.jsx
+++ b/src/pages/homePage/HomePage.jsx
@@ -9,7 +9,6 @@ import HomeHotEvent from './HomeHotEvent';
 import DailyModal from '../../components/DailyModal';
 import HelpBox from '../../components/HelpBox';
 import { Z_INDEX, STORAGE_KEYS, COLORS } from '../../constants/appConstants';
-import NotifyModal from '../notificationPage/NotificationPage';
 import { getBannerImages } from '../../services/api/event';
 
 const AppContainer = styled.div`
@@ -26,21 +25,6 @@ const MainContentContainer = styled.div`
   align-items: center;
   flex-direction: column;
   padding: 0 0 80px 0;
-`;
-
-const LoadingOverlay = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: ${COLORS.OVERLAY_BLACK};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: white;
-  font-size: 24px;
-  z-index: ${Z_INDEX.MODAL};
 `;
 
 const InstallPromptContainer = styled.div`
@@ -174,7 +158,7 @@ export default function HomePage() {
   const [isPWAInstalled, setIsPWAInstalled] = useState(false);
   const [deferredPrompt, setDeferredPrompt] = useState(null); // PWA 설치 프롬프트 저장
   const [showInstallPrompt, setShowInstallPrompt] = useState(false); // 설치 프롬프트 표시 여부
-  const [isLoading, setIsLoading] = useState(false);
+  const [, setIsLoading] = useState(false);
   const [bannerImages, setBannerImages] = useState([]);
   const [showPushNotificationPrompt, setShowPushNotificationPrompt] =
     useState(false);

--- a/src/pages/likedPage/LikedEventPage.jsx
+++ b/src/pages/likedPage/LikedEventPage.jsx
@@ -94,7 +94,7 @@ export default function LikedEventPage() {
     } finally {
       setLoading(false);
     }
-  }, [loading, hasMore, page, keyword]);
+  }, [loading, hasMore, isError, page, pageSize, keyword]);
 
   // Handle infinite scroll
   useEffect(() => {
@@ -107,13 +107,14 @@ export default function LikedEventPage() {
       { threshold: 1 },
     );
 
-    if (bottomRef.current) {
-      observer.observe(bottomRef.current);
+    const currentRef = bottomRef.current;
+    if (currentRef) {
+      observer.observe(currentRef);
     }
 
     return () => {
-      if (bottomRef.current) {
-        observer.unobserve(bottomRef.current);
+      if (currentRef) {
+        observer.unobserve(currentRef);
       }
     };
   }, [loading, hasMore, fetchData]);

--- a/src/pages/myPage/MyPage.jsx
+++ b/src/pages/myPage/MyPage.jsx
@@ -123,18 +123,12 @@ const MyPage = () => {
     });
   };
 
-  const handleFrequentlyAskedQuestionsClick = () => {};
-
   const handleFeedBackClick = () => {
     window.open(
       'https://docs.google.com/forms/d/e/1FAIpQLSfSyN05EK3L9N7DMfQlpAnrebcuIGzadeANgELlGqrdlKeeqg/viewform',
       '_blank',
     );
   };
-
-  const handleNofificationClick = () => {};
-
-  const handleVersionClick = () => {};
 
   const handleLogoutBtnClick = () => {
     Swal.fire({

--- a/src/pages/searchPage/SearchDropBox.jsx
+++ b/src/pages/searchPage/SearchDropBox.jsx
@@ -108,6 +108,7 @@ function SearchDropBox({
         setOption2('아주대 공지사항');
         break;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [option1]);
 
   useEffect(() => {
@@ -128,6 +129,7 @@ function SearchDropBox({
     };
 
     fetchDataAndUpdateState();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [option2]);
 
   return (

--- a/src/pages/searchPage/SearchEventPage.jsx
+++ b/src/pages/searchPage/SearchEventPage.jsx
@@ -82,7 +82,7 @@ export default function SearchEventPage() {
     } finally {
       setLoading(false);
     }
-  }, [loading, hasMore, page, option2, keyword]);
+  }, [loading, hasMore, isError, page, pageSize, option2, keyword]);
 
   // Handle infinite scroll
   useEffect(() => {
@@ -95,13 +95,14 @@ export default function SearchEventPage() {
       { threshold: 1 },
     );
 
-    if (bottomRef.current) {
-      observer.observe(bottomRef.current);
+    const currentRef = bottomRef.current;
+    if (currentRef) {
+      observer.observe(currentRef);
     }
 
     return () => {
-      if (bottomRef.current) {
-        observer.unobserve(bottomRef.current);
+      if (currentRef) {
+        observer.unobserve(currentRef);
       }
     };
   }, [loading, hasMore, fetchData]);

--- a/src/pages/subscribePage/KeywordBar.jsx
+++ b/src/pages/subscribePage/KeywordBar.jsx
@@ -133,7 +133,6 @@ const KeywordBar = ({ onKeywordSelect, showGuide }) => {
     setIsKeywordTabRead,
     subscribedKeywords,
     markKeywordAsRead,
-    fetchSubscribedKeywords,
   } = useSubscriptionStore();
   const navigate = useNavigate();
   const [selectedKeyword, setSelectedKeyword] = useState(null);

--- a/src/pages/subscribePage/KeywordSubscribePage.jsx
+++ b/src/pages/subscribePage/KeywordSubscribePage.jsx
@@ -265,18 +265,6 @@ const TopicButton = styled.button`
   font-size: clamp(0.7rem, 2vw, 1rem); /* 글자 크기 조절 */
 `;
 
-const TopicDisplay = styled.div`
-  position: absolute;
-  right: 10px;
-  top: 50%;
-  transform: translateY(-50%);
-  background-color: #f1f1f1;
-  border-radius: 4px;
-  padding: 5px 10px;
-  font-size: clamp(0.8rem, 2.5vw, 1rem); /* 글자 크기 조절 */
-  color: ${COLORS.DARK_GARY_TEXT};
-`;
-
 const KeywordError = styled.div`
   display: flex;
   justify-content: start;
@@ -516,6 +504,7 @@ export default function KeywordSubscribePage() {
 
     fetchMenuItems();
     fetchUserKeywords();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleCategoryClick = (category) => {

--- a/src/pages/subscribePage/KeywordTab.jsx
+++ b/src/pages/subscribePage/KeywordTab.jsx
@@ -4,7 +4,6 @@ import KeywordBar from './KeywordBar';
 import SearchBar from '../../components/SearchBar';
 import EventCard from '../../components/events/EventCard';
 import { getPostsByKeyword } from '../../services/api/event';
-import useSubscriptionStore from '../../store/useSubscriptionStore';
 import { COLORS, LIMITS } from '../../constants/appConstants';
 
 const AppContainer = styled.div`
@@ -37,10 +36,6 @@ const MessageContainer = styled.div`
 `;
 
 export default function KeywordTab({ showGuide }) {
-  const { setIsKeywordTabRead } = useSubscriptionStore((state) => ({
-    setIsKeywordTabRead: state.setIsKeywordTabRead,
-  }));
-
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(0);
@@ -85,6 +80,7 @@ export default function KeywordTab({ showGuide }) {
     };
 
     fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page, selectedKeyword]);
 
   // 무한 스크롤에서 중복 호출 방지
@@ -98,13 +94,14 @@ export default function KeywordTab({ showGuide }) {
       { threshold: 1 },
     );
 
-    if (bottomRef.current) {
-      observer.observe(bottomRef.current);
+    const currentRef = bottomRef.current;
+    if (currentRef) {
+      observer.observe(currentRef);
     }
 
     return () => {
-      if (bottomRef.current) {
-        observer.unobserve(bottomRef.current);
+      if (currentRef) {
+        observer.unobserve(currentRef);
       }
     };
   }, [hasMore, loading]);

--- a/src/pages/subscribePage/SubscribeBar.jsx
+++ b/src/pages/subscribePage/SubscribeBar.jsx
@@ -287,6 +287,7 @@ const SubscribeBar = ({ onTopicSelect, showGuide }) => {
 
   useEffect(() => {
     fetchSubscribeItems();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [menuItems]);
 
   useEffect(() => {
@@ -301,6 +302,7 @@ const SubscribeBar = ({ onTopicSelect, showGuide }) => {
       // 읽지 않은 항목이 있는 경우, isTopicTabRead를 false로 설정
       setIsTopicTabRead(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [subscribeItems, isTopicTabRead]);
 
   const handleSubscribe = async (topic) => {

--- a/src/pages/subscribePage/SubscribePage.jsx
+++ b/src/pages/subscribePage/SubscribePage.jsx
@@ -107,7 +107,7 @@ const GuideMessage = styled.div`
 
 export default function SubscribePage() {
   const location = useLocation();
-  const { subscribeItems, subscribedKeywords, fetchSubscribeItems, fetchSubscribedKeywords } = useSubscriptionStore();
+  const { subscribeItems, subscribedKeywords, fetchSubscribedKeywords } = useSubscriptionStore();
   const [activeTab, setActiveTab] = useState(
     location.state?.activeTab || 'subscribe',
   );
@@ -125,13 +125,9 @@ export default function SubscribePage() {
   }, [subscribeItems, subscribedKeywords, activeTab]);
 
   useEffect(() => {
-    // fetchSubscribeItems();
     fetchSubscribedKeywords(); // 여기에서 가져와야 키워드 알림 탭의 뱃지를 보여줄 수 있음
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const handleTabClick = async (tabName) => {
-    setActiveTab(tabName);
-  };
 
   const getGuideMessage = (activeTab) => {
     if (activeTab === 'subscribe') {

--- a/src/pages/subscribePage/SubscribeTab.jsx
+++ b/src/pages/subscribePage/SubscribeTab.jsx
@@ -5,7 +5,7 @@ import SubscribeBar from './SubscribeBar';
 import SubscribeEvent from './SubscribeEvent';
 import { getEventsByCategory, getSubscribedEvents } from '../../services/api/event';
 import SearchBar from '../../components/SearchBar';
-import { COLORS, LIMITS, STORAGE_KEYS } from '../../constants/appConstants';
+import { COLORS, LIMITS } from '../../constants/appConstants';
 
 const AppContainer = styled.div`
   display: flex;
@@ -31,8 +31,6 @@ export default function SubscribeTab({ showGuide }) {
   const [selectedTopic, setSelectedTopic] = useState(null);
   const pageSize = LIMITS.PAGE_SIZE;
   const bottomRef = useRef(null);
-
-  const accessToken = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
 
   const fetchData = useCallback(async () => {
     if (loading || !hasMore || isError) return;
@@ -64,7 +62,7 @@ export default function SubscribeTab({ showGuide }) {
     } finally {
       setLoading(false);
     }
-  }, [loading, hasMore, isError, page, keyword, selectedTopic]);
+  }, [loading, hasMore, isError, page, pageSize, keyword, selectedTopic]);
 
   // Handle infinite scroll
   useEffect(() => {
@@ -77,13 +75,14 @@ export default function SubscribeTab({ showGuide }) {
       { threshold: 1 },
     );
 
-    if (bottomRef.current) {
-      observer.observe(bottomRef.current);
+    const currentRef = bottomRef.current;
+    if (currentRef) {
+      observer.observe(currentRef);
     }
 
     return () => {
-      if (bottomRef.current) {
-        observer.unobserve(bottomRef.current);
+      if (currentRef) {
+        observer.unobserve(currentRef);
       }
     };
   }, [loading, hasMore, fetchData]);
@@ -101,6 +100,7 @@ export default function SubscribeTab({ showGuide }) {
 
   useEffect(() => {
     fetchData(selectedTopic); // Topic이나 페이지 변경 시 데이터 재로드
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTopic]);
 
   return (


### PR DESCRIPTION
## #️⃣ 연관 이슈

> (#이슈번호)

## 💻 작업 내용

- 미사용 변수/import 제거

  - `DeleteAccount.jsx` — accessToken, STORAGE_KEYS import 제거
  - `ProfileModification.jsx` — useState, useEffect import, accessToken, STORAGE_KEYS import 제거
  - `EventDetail.jsx` — ModalOverlay, LinkButton styled-component 제거
  - `HomePage.jsx` — NotifyModal import, LoadingOverlay styled-component 제거, isLoading → setIsLoading만 유지
  - `MyPage.jsx` — 미사용 핸들러 3개 제거
  - `KeywordBar.jsx` — fetchSubscribedKeywords 제거
  - `KeywordSubscribePage.jsx` — TopicDisplay styled-component 제거
  - `KeywordTab.jsx` — setIsKeywordTabRead, store import 제거
  - `SubscribePage.jsx` — fetchSubscribeItems, handleTabClick 제거
  - `SubscribeTab.jsx` — accessToken, STORAGE_KEYS import 제거

- Hook 의존성 수정

  - `App.js`, `HelpBox.jsx` — deps에 함수 추가
  - `LikedEventPage.jsx`, `SearchEventPage.jsx`, `SubscribeTab.jsx` — isError, pageSize deps 추가
  - 의도적으로 마운트 시 1회만 실행해야 하는 경우 — eslint-disable 주석 처리

- ref cleanup 수정
  - 4개 파일에서 bottomRef.current를 로컬 변수에 복사 후 cleanup에서 사용

- 접근성
  - `PrivacyAgreement.jsx` — 빈 `<h2>`에 aria-hidden 추가


## 추가내용

- claude code를 통해 ESLint 오류 코드를 모두 수정하였더니 수정 코드가 4000줄이 되었습니다
- vercel 버전 업데이트 (1.3.1 -> 1.6.1)