### PR TITLE
fix: /login 무한 새로고침 및 로딩 오버레이 고착 버그 수정

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -44,7 +44,7 @@ api.interceptors.response.use(
       } catch {
         clearAuth();
         localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN);
-        Swal.fire({
+        await Swal.fire({
           icon: 'warning',
           title: '타임오버',
           text: '로그인 시간이 만료되어 로그아웃 되었습니다.',

--- a/src/services/fcm/GetUserPermission.jsx
+++ b/src/services/fcm/GetUserPermission.jsx
@@ -55,6 +55,7 @@ const GetUserPermission = async (setIsLoading) => {
           console.log('token already saved');
         }
       } catch {
+        setIsLoading(false);
         Toast.fire({
           icon: 'error',
           title: `알림 토큰 요청 실패`,


### PR DESCRIPTION
## #️⃣ 연관 이슈

> #132 

## 💻 작업 내용

>  기존 버그는  isPublicPath + _retry 플래그로 이미 해결됨. 추가로 로딩 오버레이 고착 및 타임오버 알림 미표시 버그 수정  

  - `GetUserPermission` 내부 `catch` 블록에 `setIsLoading(false)` 추가
    — FCM 토큰 취득 실패 시 로딩 오버레이가 해제되지 않던 문제 수정
  - `api.js` 응답 인터셉터의 `Swal.fire()`에 `await` 추가
    — redirect 전에 페이지가 이동되어 "타임오버" 알림이 사용자에게 보이지 않던 문제 수정


### 테스트 결과 or 스크린샷 (선택)

## 💬 리뷰 요구사항 (선택)

- [ ] 알림 권한 허용 상태에서 FCM 토큰 취득 실패 시 로딩 오버레이가 정상적으로 해제되는지 확인
- [ ] accessToken·refreshToken 모두 만료된 상태에서 "타임오버" Swal 알림이 표시된 후 `/login`으로 이동하는지 확인
